### PR TITLE
cancelled commits show display for next train

### DIFF
--- a/core/train.go
+++ b/core/train.go
@@ -719,6 +719,10 @@ func cancelTrain(r *http.Request) response {
 			http.StatusInternalServerError)
 	}
 
+	// add commits back to the head of the queue when train is cancelled.
+	dataClient.PrependCommits(train.Commits)
+	train.HeadSHA = train.TailSHA
+
 	datadog.Incr("train.cancel", train.DatadogTags())
 
 	duration := train.CancelledAt.Value.Sub(train.CreatedAt.Value)

--- a/services/data/data.go
+++ b/services/data/data.go
@@ -59,6 +59,7 @@ type Client interface {
 	RestartJob(*types.Job, string) error
 
 	WriteCommits([]*types.Commit) ([]*types.Commit, error)
+	PrependCommits([]*types.Commit) ([]*types.Commit, error)
 	LatestCommitForTrain(*types.Train) (*types.Commit, error)
 	TrainsByCommit(*types.Commit) ([]*types.Train, error)
 

--- a/services/data/methods.go
+++ b/services/data/methods.go
@@ -936,6 +936,18 @@ func (d *dataClient) WriteCommits(commits []*types.Commit) ([]*types.Commit, err
 	return newCommits, nil
 }
 
+func (d *dataClient) PrependCommits(commits []*types.Commit) ([]*types.Commit, error) {
+	newCommits := make([]*types.Commit, 0)
+	prepended := make([]string, 0)
+	for _, commit := range commits {
+		newCommits = append([]*types.Commit{commit}, newCommits...)
+		prepended = append(prepended, fmt.Sprintf("(ID, SHA, Branch, AuthorName) %v, %v, %v, %v", commit.ID, commit.SHA, commit.Branch, commit.AuthorName))
+
+	}
+	datadog.Info("Prepended commits to queue: %v", strings.Join(prepended, "\n"))
+	return newCommits, nil
+}
+
 func (d *dataClient) LatestCommitForTrain(train *types.Train) (*types.Commit, error) {
 	commit := &types.Commit{}
 	query := d.Client.QueryTable(commit)


### PR DESCRIPTION
This happens by putting commits back into the commit queue. Note that this is for UI purposes only, the Jenkin job does a pull on master anyway to get the latest changes on the next train if previous was canceled.